### PR TITLE
Support read attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,13 @@ try {
       if (nodes.length) {
         var output = [];
         for (var i = 0; i < nodes.length; i++) {
-          output.push(nodes[i].firstChild.data);
+          var node = nodes[i];
+          var firstChild = node.firstChild;
+          if (firstChild) {
+            output.push(firstChild.data);
+          } else {
+            output.push(node.value);
+          }
         }
         core.setOutput('info', output);
         console.log(`Output: ${output}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-xml-info",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Get Information from XML files to use into your GitHub workflows",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Supports to read attribute value.

For example, given the xml file as below
```xml
<plugin key="plugin-key">content</plugin>
```

xPath `//plugin/@key` will return `plugin-key`

With current implementation it throws error:
```
Welcome to Get-XML-Version.
File to read: ./atlassian-plugin.xml
XPath: /atlassian-plugin/@key
File was read successfully. Proceeding to parse DOM.
Found 1 nodes.
/Users/debt/Workspace/get-xml-info/index.js:43
          output.push(firstChild.data);
                                 ^

TypeError: Cannot read property 'data' of null
    at read (/Users/debt/Workspace/get-xml-info/index.js:43:34)
    at FSReqCallback.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:63:3)
```