### PR TITLE
Handle Ability to Allow for Zero Nodes Found

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 **Required** The xpath of the nodes from which you want to retrieve information. Default `"//element"`.
 
+### `allow-zero-nodes`
+
+**Optional** Finding zero nodes is not an error. Default `false`.
+
 ## Example usage
 
     uses: mavrosxristoforos/get-xml-info@1.0

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 **Required** The xpath of the nodes from which you want to retrieve information. Default `"//element"`.
 
-### `allow-zero-nodes`
+### `zero-nodes-action`
 
-**Optional** Finding zero nodes is not an error. Default `false`.
+**Optional** How to handle finding Zero (0) nodes. Default `error`.
 
 ## Example usage
 
@@ -47,6 +47,8 @@ Namespaces are currently not supported, so you can use the `local-name()` XPath 
 ### `info`
 
 The content of the matched nodes. If your XPath matches more than one nodes, the output is an array.
+
+If `zero-nodes-action='warn'` and no nodes are found, `info` will contain the message "Zero Nodes Found."
 
 ## Example usage of output in a workflow
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'The XPath of a node, to fetch its contents as output.'
     required: true
     default: '//element'
+  allow-zero-nodes:
+    description: 'Allow zero nodes to not fail'
+    required: false
+    default: false
 runs:
   using: 'node16'
   main: 'index.js'

--- a/action.yml
+++ b/action.yml
@@ -13,10 +13,10 @@ inputs:
     description: 'The XPath of a node, to fetch its contents as output.'
     required: true
     default: '//element'
-  allow-zero-nodes:
+  zero-nodes-action:
     description: 'Allow zero nodes to not fail'
     required: false
-    default: false
+    default: 'error'
 runs:
   using: 'node16'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ try {
   var xmlFile = (typeof argv.f !== 'undefined') ? argv.f : process.env.GITHUB_WORKSPACE+'/'+core.getInput('xml-file', { required: true });
   var xpathToSearch = (typeof argv.p !== 'undefined') ? argv.p : core.getInput('xpath', { required: true });
   var debug = (typeof argv.d !== 'undefined') ? true : false;
+  var allowZeroNodes = (typeof argv.z !== 'undefined') ? true : core.getInput('allow-zero-nodes', {required: false}) || false
 
   console.log(`File to read: ${xmlFile}`);
   console.log(`XPath: ${xpathToSearch}`);
@@ -35,7 +36,7 @@ try {
 
       console.log(`Found ${nodes.length} nodes.`);
 
-      if (nodes.length) {
+      if (allowZeroNodes || nodes.length) {
         var output = [];
         for (var i = 0; i < nodes.length; i++) {
           var node = nodes[i];
@@ -50,6 +51,7 @@ try {
         console.log(`Output: ${output}`);
       }
       else {
+        console.error('Your xpath did not return any nodes.')
         core.setFailed('Your xpath did not return any nodes.');
       }
     }

--- a/index.js
+++ b/index.js
@@ -8,11 +8,13 @@ try {
   var xmlFile = (typeof argv.f !== 'undefined') ? argv.f : process.env.GITHUB_WORKSPACE+'/'+core.getInput('xml-file', { required: true });
   var xpathToSearch = (typeof argv.p !== 'undefined') ? argv.p : core.getInput('xpath', { required: true });
   var debug = (typeof argv.d !== 'undefined') ? true : false;
-  var allowZeroNodes = (typeof argv.z !== 'undefined') ? true : core.getInput('allow-zero-nodes', {required: false}) || false
+  var allowZeroNodes = (typeof argv.z !== 'undefined') ? true : (core.getInput('allow-zero-nodes', {required: false}) || false)
 
   console.log(`File to read: ${xmlFile}`);
   console.log(`XPath: ${xpathToSearch}`);
-
+  if (allowZeroNodes) {
+    console.log('Zero Nodes Allowed')
+  }
   var xpath = require('xpath'), dom = require('xmldom').DOMParser
  
   fs.readFile(xmlFile, 'utf8', function read(err, data) {


### PR DESCRIPTION
Added option `zero-nodes-action` with allowed values of 'error (default), silent, warn'

If set to error, the functionality is unchanged.

If set to warn the `info` output is set to "Zero Nodes Found."

If set to silent, output is set to whatever `nodes` is set to.