### PR TITLE
Make it work for string-typed xpath expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,11 @@ try {
 
       console.log(`Found ${nodes.length} nodes.`);
 
-      if (['silent','warn'].includes(zeroNodesAction) || nodes.length) {
+      if (typeof(nodes) == 'string')
+	  {
+		  core.setOutput('info', nodes)
+	  }
+      else if (['silent','warn'].includes(zeroNodesAction) || nodes.length) {
         var output = [];
         for (var i = 0; i < nodes.length; i++) {
           var node = nodes[i];


### PR DESCRIPTION
This pull request makes the action work for expressions such as this one:
`concat(//VersionPrefix/text(), "-", //VersionSuffix/text())`

so far the characters in the result are treated as individual nodes by the code. 