### PR TITLE
Make it work for string-typed xpath expressions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,4 @@
-name: 'Get XML Info'
-author: 'mavrosxristoforos'
+name: 'Get XPath'
 description: 'Get Information from XML files to use into your GitHub workflows'
 branding:
   icon: 'info'  

--- a/index.js
+++ b/index.js
@@ -47,7 +47,11 @@ try {
 
       console.log(`Found ${nodes.length} nodes.`);
 
-      if (['silent','warn'].includes(zeroNodesAction) || nodes.length) {
+      if (typeof(nodes) == 'string')
+	  {
+		  core.setOutput('info', nodes)
+	  }
+      else if (['silent','warn'].includes(zeroNodesAction) || nodes.length) {
         var output = [];
         for (var i = 0; i < nodes.length; i++) {
           var node = nodes[i];


### PR DESCRIPTION
Sorry. Old PR #19 got closed after I renamed my repo and branch.

> Hi @m-ringler and thank you for your contribution! Could you please also provide an example of your XML?

Sure, this is the full beauty

<Project>
	<PropertyGroup>
		<TargetFramework>net7.0</TargetFramework>
		<LangVersion>latest</LangVersion>
		<ImplicitUsings>enable</ImplicitUsings>
		<MSBuildCopyContentTransitively>True</MSBuildCopyContentTransitively>
		<Nullable>enable</Nullable>
		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
		<CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysis.ruleset</CodeAnalysisRuleSet>
		<GenerateDocumentationFile>True</GenerateDocumentationFile>
		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>

		<!-- Version -->
		<VersionPrefix>1.0.0</VersionPrefix>
		<VersionSuffix>alpha.21</VersionSuffix>
	</PropertyGroup>
</Project>
Only the Version elements are relevant - so you can strip everything else if you are looking for a minimal repro case.
Evaluating the XPath expression concat(//VersionPrefix/text(), "-", //VersionSuffix/text()) against this document should produce the string 1.0.0-alpha.21. See e. g. https://www.freeformatter.com/xpath-tester.htm