### PR TITLE
remove automatic building in favor of just testing build completion

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [windows-latest, macos-latest]
         node: ["20"]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,10 +1,9 @@
 name: Build & Test
 
 on:
-  pull_request:
-    paths-ignore:
-      - "**.md"
   push:
+    branches:
+      - '**' 
     paths-ignore:
       - "**.md"
   workflow_dispatch:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,23 +1,20 @@
-name: Build & Test
+name: Build Test
 
 on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
   push:
-    branches:
-      - '**' 
     paths-ignore:
       - "**.md"
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
-  test-win-mac:
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         node: ["20"]
     steps:
       - uses: actions/checkout@v4
@@ -35,29 +32,3 @@ jobs:
 
       - name: Build new release
         run: ncc build index.js --license licenses.txt
-
-  test-and-build-ubuntu:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js 20
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: 'npm'
-
-      - name: Install dependencies with NPM
-        run: |
-          npm i -g @vercel/ncc
-          npm install
-
-      - name: Build new release
-        run: ncc build index.js --license licenses.txt
-
-      - name: Open pull request with changes
-        uses: peter-evans/create-pull-request@v6
-        with:
-          title: New build
-          branch: auto-build
-          delete-branch: true

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  test:
+  test-win-mac:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -36,7 +36,7 @@ jobs:
       - name: Build new release
         run: ncc build index.js --license licenses.txt
 
-  build:
+  test-and-build-ubuntu:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  build:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -26,6 +26,25 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+          cache: 'npm'
+
+      - name: Install dependencies with NPM
+        run: |
+          npm i -g @vercel/ncc
+          npm install
+
+      - name: Build new release
+        run: ncc build index.js --license licenses.txt
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
           cache: 'npm'
 
       - name: Install dependencies with NPM


### PR DESCRIPTION
The build/test action was failing for new PRs and new releases (since these both target commits rather than branches). It was also doing un-needed extra work by submitting the PR three times (because of the multi-platform strategy). Sorry I didn't catch this in my prior commit.